### PR TITLE
fix: downgrade commons-io in gzip for Android 7+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'commons-io:commons-io:2.6'
+    implementation 'commons-io:commons-io:2.5'
     implementation 'org.apache.commons:commons-compress:1.1'
 }
 


### PR DESCRIPTION
Sentry reported a bug caused by `react-native-gzip`,
created by `commons-io@2.6`.

We decide to patch the library with `patch-package`
to use a commons-io version
compatible with Android 7+

The application was tested on AVD with v7.1 and 5.1 and was not able to reproduce the error

Please refer to the initial PR on this issue https://github.com/cozy/cozy-flagship-app/pull/511