### PR TITLE
fix: Revert compatibility fixes for Android 5+ support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,9 +74,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation 'commons-io:commons-io:2.5'
-    implementation 'org.apache.commons:commons-compress:1.21'
-    // https://mvnrepository.com/artifact/org.kamranzafar/jtar
-    implementation 'org.kamranzafar:jtar:2.2'
+    implementation 'org.apache.commons:commons-compress:1.1'
 }
 
 def configureReactNativePom(def pom) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'commons-io:commons-io:2.5'
+    implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.commons:commons-compress:1.1'
 }
 

--- a/android/src/main/java/com/reactlibrary/GzipModule.java
+++ b/android/src/main/java/com/reactlibrary/GzipModule.java
@@ -1,7 +1,5 @@
 package com.reactlibrary;
 
-import android.os.Build;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -13,10 +11,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.BufferedOutputStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveException;
@@ -27,7 +21,6 @@ import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.io.FileUtils;
-import org.kamranzafar.jtar.TarInputStream;
 
 public class GzipModule extends ReactContextBaseJavaModule {
 
@@ -116,89 +109,41 @@ public class GzipModule extends ReactContextBaseJavaModule {
     public void unGzipTar(String source, String target, Boolean force, Promise promise) {
         File sourceFile = new File(source);
         File targetFile = new File(target);
-        if (!checkDir(sourceFile, targetFile, force)) {
+        if(!checkDir(sourceFile, targetFile, force)){
             promise.reject("-2", "error");
             return;
         }
 
-        // Check the Android API level
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            // Android versions below 8.0 (API level 26)
-            try {
-                FileInputStream fis = new FileInputStream(sourceFile);
-                GZIPInputStream gis = new GZIPInputStream(fis);
-                untar2(gis, targetFile); // Assume untar2 is a method you've implemented for manual extraction
-                fis.close();
-                gis.close();
+        ArchiveInputStream inputStream = null;
+        FileInputStream fileInputStream;
 
-                WritableMap map = Arguments.createMap();
-                map.putString("path", targetFile.getAbsolutePath());
-                promise.resolve(map);
-            } catch (IOException e) {
-                e.printStackTrace();
-                promise.reject("-2", "ungzip error for API < 26");
-            }
-        } else {
-            // For Android API level 26 and above
-            try (FileInputStream fileInputStream = FileUtils.openInputStream(sourceFile)) {
-                final CompressorInputStream compressorInputStream = new CompressorStreamFactory()
-                        .createCompressorInputStream(CompressorStreamFactory.GZIP, fileInputStream);
-                try (ArchiveInputStream inputStream = new ArchiveStreamFactory()
-                        .createArchiveInputStream(ArchiveStreamFactory.TAR, compressorInputStream)) {
-                    ArchiveEntry archiveEntry = inputStream.getNextEntry();
+        try{
+            fileInputStream = FileUtils.openInputStream(sourceFile);
+            final CompressorInputStream compressorInputStream = new CompressorStreamFactory()
+                    .createCompressorInputStream(CompressorStreamFactory.GZIP, fileInputStream);
+            inputStream = new ArchiveStreamFactory()
+                    .createArchiveInputStream(ArchiveStreamFactory.TAR, compressorInputStream);
+            ArchiveEntry archiveEntry = inputStream.getNextEntry();
 
-                    while (archiveEntry != null) {
-                        File destFile = new File(targetFile, archiveEntry.getName());
-                        if (archiveEntry.isDirectory()) {
-                            destFile.mkdirs();
-                        } else {
-                            try (FileOutputStream outputStream = FileUtils.openOutputStream(destFile)) {
-                                IOUtils.copy(inputStream, outputStream);
-                            }
-                        }
-                        archiveEntry = inputStream.getNextEntry();
-                    }
-
-                    WritableMap map = Arguments.createMap();
-                    map.putString("path", targetFile.getAbsolutePath());
-                    promise.resolve(map);
+            while (archiveEntry != null) {
+                File destFile = new File(targetFile, archiveEntry.getName());
+                if (archiveEntry.isDirectory()) {
+                    destFile.mkdirs();
+                } else {
+                    final FileOutputStream outputStream = FileUtils.openOutputStream(destFile);
+                    IOUtils.copy(inputStream, outputStream);
+                    outputStream.close();
                 }
-            } catch (IOException | CompressorException | ArchiveException e) {
-                e.printStackTrace();
-                promise.reject("-2", "ungzip error");
+                archiveEntry = inputStream.getNextEntry();
             }
+
+            WritableMap map = Arguments.createMap();
+            map.putString("path", targetFile.getAbsolutePath());
+            promise.resolve(map);
+        } catch (IOException | CompressorException | ArchiveException e) {
+            e.printStackTrace();
+            promise.reject("-2", "ungzip error");
         }
-    }
-
-    private void untar2(GZIPInputStream gis, File targetFile) throws IOException {
-        // Create a TarInputStream from the GZIPInputStream
-        TarInputStream tis = new TarInputStream(gis);
-        org.kamranzafar.jtar.TarEntry entry;
-
-        // Iterate through the entries in the TAR stream
-        while ((entry = tis.getNextEntry()) != null) {
-            File outputFile = new File(targetFile, entry.getName());
-
-            // Check if the entry is a directory
-            if (entry.isDirectory()) {
-                outputFile.mkdirs();
-            } else {
-                // Ensure parent directories exist
-                outputFile.getParentFile().mkdirs();
-
-                // Write the entry to file
-                try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(outputFile))) {
-                    int count;
-                    byte data[] = new byte[2048];
-
-                    // Read data from the entry and write it to the output file
-                    while ((count = tis.read(data)) != -1) {
-                        bos.write(data, 0, count);
-                    }
-                }
-            }
-        }
-        tis.close();
     }
 
     private Boolean checkDir(File sourceFile, File targetFile, Boolean force) {
@@ -212,7 +157,11 @@ public class GzipModule extends ReactContextBaseJavaModule {
             }
 
             try {
-                deleteRecursively(targetFile);
+                if (targetFile.isDirectory()) {
+                    FileUtils.deleteDirectory(targetFile);
+                } else {
+                    targetFile.delete();
+                }
                 targetFile.mkdirs();
             } catch (IOException ex) {
                 return false;
@@ -220,22 +169,5 @@ public class GzipModule extends ReactContextBaseJavaModule {
         }
         return true;
     }
-
-    private void deleteRecursively(File file) throws IOException {
-        if (file.isDirectory()) {
-            // List all the directory contents
-            File[] files = file.listFiles();
-            if (files != null) {  // Some JVMs return null for empty directories
-                for (File child : files) {
-                    // Recursive delete
-                    deleteRecursively(child);
-                }
-            }
-        }
-
-        // Check if file actually exists before deletion
-        if (!file.delete()) {
-            throw new IOException("Failed to delete file: " + file.getAbsolutePath());
-        }
-    }
 }
+


### PR DESCRIPTION
In https://github.com/cozy/react-native-gzip/commit/a7a9610cf885509475c37c24ed4db2b5d72bc1fd  and https://github.com/cozy/react-native-gzip/commit/8e41347512f0ecc374617f970990e31609464c39 we changed compression libraries in order to increase Android minimum compatibility from SDK 26 (Android 8) to SDK 22 (Android 5.1)

With latest Flagship app changes we encountered build issues due to this change. This is mainly due to removal of geolocation libraries that shared common dependencies

We should be able to fix those dependencies, but because latest ReactNative versions break support for Android 5 and 6 and because we will also rework this library for nitro-modules support, we chose not to investigate this for now and revert this commit instead. However we also loose support for Android 7 but this impact only a very small number of users (less than 10)